### PR TITLE
Integration raccourci script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
               node-version: 20.17
           - run: npm ci
           - run: npm run build
+          - run: npm link
           - run: npm run lint
           - run: npm run test
           

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,5 @@ WORKDIR /app
 COPY ./package.json ./package-lock.json .
 RUN npm install --production
 COPY --from=build /app/dist /app/dist
-
+RUN npm link
 ENTRYPOINT ["node", "/app/dist/index.js"]

--- a/package.json
+++ b/package.json
@@ -5,14 +5,14 @@
   "main": "index.js",
   "scripts": {
     "build": "rm -rf ./dist && tsc",
-    "start": "npm run build && node dist/index.js",
+    "start": "npm run build && node dist/index.js && npm link",
     "start-db": "docker container run -d --name vehicle-database -e POSTGRES_USER=vehicle -e POSTGRES_PASSWORD=vehicle -e POSTGRES_DB=vehicle -p 5432:5432 postgis/postgis:16-3.4-alpine",
     "stop-db": "docker container rm -f vehicle-database",
     "lint": "eslint ./src",
     "test": "jest"
   },
   "bin": {
-    "vehicle-cli": "./vehicle-cli.js"
+    "vehicle-cli": "./bin/vehicle-cli.js"
   },
   "author": "rt",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "lint": "eslint ./src",
     "test": "jest"
   },
+  "bin": {
+    "vehicle-cli": "./vehicle-cli.js"
+  },
   "author": "rt",
   "license": "ISC",
   "devDependencies": {


### PR DESCRIPTION
Rectification de la méthode pour démarrer l'outil de commande. 
Il n'est plus obligatoire de spécifier le fichier JS (./....) avant de lancer la commande de création d'un véhicule.